### PR TITLE
Close socket when setsockopt() fail.

### DIFF
--- a/gnss/gnss_hw_conn.cpp
+++ b/gnss/gnss_hw_conn.cpp
@@ -275,6 +275,8 @@ void GnssHwConn::gpsSocketServerThread(void* paramGnssHwConn) {
 
     if (setsockopt(gpsSocketServerFd, SOL_SOCKET, SO_REUSEADDR, &so_reuseaddr, sizeof(int)) < 0) {
         ALOGE("%s setsockopt(SO_REUSEADDR) failed. gpsSocketServerFd: %d\n", __PRETTY_FUNCTION__, gpsSocketServerFd);
+        close(gpsSocketServerFd);
+        gpsSocketServerFd = -1;
         return;
     }
     pGnssHwConn->m_gpsSocketServerFd.reset(gpsSocketServerFd);


### PR DESCRIPTION
If setsockopt() fail, close the socket.
Tracked-On: OAM-106897